### PR TITLE
fix loop of spawn

### DIFF
--- a/Assets/Scripts/Gameplay/Collectables/ConsumableSpawnSystem/ConsumableSpawnersInvoker.cs
+++ b/Assets/Scripts/Gameplay/Collectables/ConsumableSpawnSystem/ConsumableSpawnersInvoker.cs
@@ -47,6 +47,7 @@ namespace Gameplay.Collectables.ConsumableSpawnSystem
 
             int index = Random.Range(0, _spawners.Length);
             _spawners[index].Spawn();
+            StartSpawn();
         }
 
         public void Dispose()

--- a/Assets/Scripts/Infrastructure/Installers/Global/ServicesInstaller.cs
+++ b/Assets/Scripts/Infrastructure/Installers/Global/ServicesInstaller.cs
@@ -59,10 +59,9 @@ namespace Infrastructure
 
         private void BindTimeService()
         {
-            Container.Bind(typeof(ITicker), typeof(IDisposable))
+            Container.Bind(typeof(ITicker), typeof(ITickable), typeof(IDisposable))
                 .To<ZenjectTicker>()
                 .AsSingle();
         }
-        
     }
 }


### PR DESCRIPTION
- поправил ZenjectTicker: в контейнере не биндился к интерфейсу ITickable
- поправил сам луп спавна  ConsumableSpawnersInvoker: не вызывался повторный спавн