### PR TITLE
fix stop spawn

### DIFF
--- a/Assets/Scripts/Gameplay/Collectables/ConsumableSpawnSystem/ConsumableSpawnersInvoker.cs
+++ b/Assets/Scripts/Gameplay/Collectables/ConsumableSpawnSystem/ConsumableSpawnersInvoker.cs
@@ -13,6 +13,7 @@ namespace Gameplay.Collectables.ConsumableSpawnSystem
         private readonly ConsumableSpawnSettings _consumableSpawnSettings;
         private readonly Cooldown.Factory _cooldownFactory;
         private readonly IGameState _gameState;
+        private readonly IPlayer _player;
         private Cooldown _spawnInvokeCooldown;
         private bool _isSpawn = false;
 
@@ -21,17 +22,20 @@ namespace Gameplay.Collectables.ConsumableSpawnSystem
             IWeaponSpawner weaponSpawner,
             ConsumableSpawnSettings consumableSpawnSettings,
             Cooldown.Factory cooldownFactory,
-            IGameState gameState)
+            IGameState gameState,
+            IPlayer player)
         {
             _consumableSpawnSettings = consumableSpawnSettings;
             _cooldownFactory = cooldownFactory;
             _gameState = gameState;
+            _player = player;
             _spawners = new ISpawner[] { firstAidKitSpawner, weaponSpawner };
 
             _spawnInvokeCooldown = _cooldownFactory.CreateFinished();
 
             _gameState.Won += OnLevelFinished;
             _gameState.PlayerDead += OnLevelFinished;
+            _player.Dead += OnLevelFinished;
         }
 
         private void OnLevelFinished()
@@ -77,6 +81,7 @@ namespace Gameplay.Collectables.ConsumableSpawnSystem
             _spawnInvokeCooldown = null;
             _gameState.Won -= OnLevelFinished;
             _gameState.PlayerDead -= OnLevelFinished;
+            _player.Dead -= OnLevelFinished;
         }
     }
 }


### PR DESCRIPTION
- фикс отключения спавна по завершения уровня поражением. Причина - событие gameState.PlayerDead - не вызывается при смерте игрока, а вызывается событие в IPlayer - Dead