### PR TITLE
fixed priority uiCamera

### DIFF
--- a/Assets/Prefabs/UI/UICamera.prefab
+++ b/Assets/Prefabs/UI/UICamera.prefab
@@ -70,7 +70,7 @@ Camera:
   field of view: 60
   orthographic: 1
   orthographic size: 12
-  m_Depth: 0
+  m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295


### PR DESCRIPTION
- изменен приоритет ui камеры на -1. 
Причина: основной камерой в геймплейной сцене становилась ui камера